### PR TITLE
Feature/polkadotv1 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,6 +3531,7 @@ checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 name = "hashed-parachain"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "color-print",
  "cumulus-client-cli",
  "cumulus-client-consensus-aura",
@@ -3541,8 +3542,10 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "futures",
  "hashed-parachain-runtime",
  "hex-literal 0.4.1",
+ "jsonrpsee",
  "log",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
@@ -3565,6 +3568,7 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "scale-info",
+ "serde",
  "smallvec",
  "sp-api",
  "sp-block-builder",
@@ -3612,6 +3616,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-bitcoin-vaults",
  "pallet-bounties",
  "pallet-child-bounties",
  "pallet-collator-selection",
@@ -5056,6 +5061,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
+name = "lite-json"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0e787ffe1153141a0f6f6d759fdf1cc34b1226e088444523812fd412a5cca2"
+dependencies = [
+ "lite-parser",
+]
+
+[[package]]
+name = "lite-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d5f9dc37c52d889a21fd701983d02bb6a84f852c5140a6c80ef4557f7dc29e"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "pallet-afloat"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6058,6 +6081,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-bitcoin-vaults"
+version = "4.0.0-dev"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "lite-json",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0#948fbd2fd1233dc26dbb9f9bbc1d2cca2c03945d"
@@ -6133,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "pallet-confidential-docs"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6254,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "pallet-fruniques"
 version = "0.1.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6271,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "pallet-fund-admin-records"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6286,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "pallet-gated-marketplace"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6411,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "pallet-mapped-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6652,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "pallet-rbac"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6888,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
+source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#abcf44e605ff64b8ab49e3c26ab9d609894022e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,7 +3612,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-bitcoin-vaults",
  "pallet-bounties",
  "pallet-child-bounties",
  "pallet-collator-selection",
@@ -5057,24 +5056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
-name = "lite-json"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0e787ffe1153141a0f6f6d759fdf1cc34b1226e088444523812fd412a5cca2"
-dependencies = [
- "lite-parser",
-]
-
-[[package]]
-name = "lite-parser"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d5f9dc37c52d889a21fd701983d02bb6a84f852c5140a6c80ef4557f7dc29e"
-dependencies = [
- "paste",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6072,26 +6053,6 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-bitcoin-vaults"
-version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?branch=fix-dependencies-polkadotv1#d19802d7ded01e44ea08325d99d21a045a3fd83a"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "lite-json",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-keystore",
  "sp-runtime",
  "sp-std",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,9 +10,13 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-hex-literal = { version = "0.4.1", optional = true }
-log = { version = "0.4.19", default-features = false }
+clap = { version = "4.3.12", features = ["derive"] }
+log = "0.4.19"
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+serde = { version = "1.0.171", features = ["derive"] }
+jsonrpsee = { version = "0.16.2", features = ["server"] }
+futures = "0.3.28"
+hex-literal = { version = "0.4.1" }
 scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
@@ -50,10 +54,10 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v1.0.0" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v1.0.0" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", features = ["rococo-native"] , branch = "release-v1.0.0" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", features = ["rococo-native"], branch = "release-v1.0.0" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v1.0.0" }
 
@@ -69,7 +73,6 @@ color-print = "0.3.4"
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-
 
 [features]
 default = []

--- a/node/src/chain_spec/hashed.rs
+++ b/node/src/chain_spec/hashed.rs
@@ -1,7 +1,5 @@
 use sc_service::ChainType;
-// use sp_core::sr25519;
-use sp_core::{crypto::UncheckedInto};
-
+use sp_core::crypto::UncheckedInto;
 use hex_literal::hex;
 
 use super::{
@@ -13,7 +11,7 @@ use hashed_parachain_runtime::{AccountId, AuraId, SudoConfig, EXISTENTIAL_DEPOSI
 
 /// Specialized `ChainSpec` for Hashed Network
 pub type HashedChainSpec =
-	sc_service::GenericChainSpec<hashed_parachain_runtime::GenesisConfig, Extensions>;
+	sc_service::GenericChainSpec<hashed_parachain_runtime::RuntimeGenesisConfig, Extensions>;
 
 /// Gen HASH chain specification
 pub fn get_chain_spec() -> HashedChainSpec {
@@ -77,12 +75,13 @@ fn hashed_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root_key: AccountId,
 	id: ParaId,
-) -> hashed_parachain_runtime::GenesisConfig {
-	hashed_parachain_runtime::GenesisConfig {
+) -> hashed_parachain_runtime::RuntimeGenesisConfig {
+	hashed_parachain_runtime::RuntimeGenesisConfig {
 		system: hashed_parachain_runtime::SystemConfig {
 			code: hashed_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
+				..Default::default()
 		},
 		balances: hashed_parachain_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1000000000000000000000000000)).collect(),
@@ -91,7 +90,7 @@ fn hashed_genesis(
 		sudo: SudoConfig { key: Some(root_key) },
 		council: Default::default(),
 		treasury: Default::default(),
-		parachain_info: hashed_parachain_runtime::ParachainInfoConfig { parachain_id: id },
+		parachain_info: hashed_parachain_runtime::ParachainInfoConfig { parachain_id: id, ..Default::default() },
 		collator_selection: hashed_parachain_runtime::CollatorSelectionConfig {
 			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
 			candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
@@ -116,6 +115,7 @@ fn hashed_genesis(
 		parachain_system: Default::default(),
 		polkadot_xcm: hashed_parachain_runtime::PolkadotXcmConfig {
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
+			..Default::default()
 		},
 	}
 }

--- a/node/src/chain_spec/luhn.rs
+++ b/node/src/chain_spec/luhn.rs
@@ -1,6 +1,5 @@
 use sc_service::ChainType;
-// use sp_core::sr25519;
-use sp_core::{crypto::UncheckedInto};
+use sp_core::crypto::UncheckedInto;
 
 use hex_literal::hex;
 
@@ -13,7 +12,7 @@ use hashed_parachain_runtime::{AccountId, AuraId, SudoConfig, EXISTENTIAL_DEPOSI
 
 /// Specialized `ChainSpec` for Hashed Network
 pub type HashedChainSpec =
-	sc_service::GenericChainSpec<hashed_parachain_runtime::GenesisConfig, Extensions>;
+	sc_service::GenericChainSpec<hashed_parachain_runtime::RuntimeGenesisConfig, Extensions>;
 
 /// Gen HASH chain specification
 pub fn get_chain_spec() -> HashedChainSpec {
@@ -76,12 +75,13 @@ fn hashed_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root_key: AccountId,
 	id: ParaId,
-) -> hashed_parachain_runtime::GenesisConfig {
-	hashed_parachain_runtime::GenesisConfig {
+) -> hashed_parachain_runtime::RuntimeGenesisConfig {
+	hashed_parachain_runtime::RuntimeGenesisConfig {
 		system: hashed_parachain_runtime::SystemConfig {
 			code: hashed_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
+				..Default::default()
 		},
 		balances: hashed_parachain_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1000000000000000000000000000)).collect(),
@@ -90,7 +90,10 @@ fn hashed_genesis(
 		sudo: SudoConfig { key: Some(root_key) },
 		council: Default::default(),
 		treasury: Default::default(),
-		parachain_info: hashed_parachain_runtime::ParachainInfoConfig { parachain_id: id },
+		parachain_info: hashed_parachain_runtime::ParachainInfoConfig {
+			parachain_id: id,
+			..Default::default()
+		},
 		collator_selection: hashed_parachain_runtime::CollatorSelectionConfig {
 			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
 			candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
@@ -115,6 +118,7 @@ fn hashed_genesis(
 		parachain_system: Default::default(),
 		polkadot_xcm: hashed_parachain_runtime::PolkadotXcmConfig {
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
+			..Default::default()
 		},
 	}
 }

--- a/node/src/chain_spec/md5.rs
+++ b/node/src/chain_spec/md5.rs
@@ -1,17 +1,17 @@
 use sc_service::ChainType;
-use sp_core::{crypto::UncheckedInto};
 use hex_literal::hex;
+use sp_core::crypto::UncheckedInto;
 
 use super::{
 	session_keys, SAFE_XCM_VERSION, Extensions,
 };
 
 use cumulus_primitives_core::ParaId;
-use hashed_parachain_runtime::{AccountId, AuraId, CouncilConfig, SudoConfig, EXISTENTIAL_DEPOSIT};
+use hashed_parachain_runtime::{AccountId, AuraId, SudoConfig, EXISTENTIAL_DEPOSIT};
 
 /// Specialized `ChainSpec` for MD5 Network.
 pub type Md5ChainSpec =
-	sc_service::GenericChainSpec<hashed_parachain_runtime::GenesisConfig, Extensions>;
+	sc_service::GenericChainSpec<hashed_parachain_runtime::RuntimeGenesisConfig, Extensions>;
 
 /// Gen MD5 chain specification
 pub fn get_chain_spec() -> Md5ChainSpec {
@@ -73,12 +73,13 @@ fn md5_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root_key: AccountId,
 	id: ParaId,
-) -> hashed_parachain_runtime::GenesisConfig {
-	hashed_parachain_runtime::GenesisConfig {
+) -> hashed_parachain_runtime::RuntimeGenesisConfig {
+	hashed_parachain_runtime::RuntimeGenesisConfig {
 		system: hashed_parachain_runtime::SystemConfig {
 			code: hashed_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
+				..Default::default()
 		},
 		balances: hashed_parachain_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1000000000000000000000000000)).collect(),
@@ -87,7 +88,10 @@ fn md5_genesis(
 		sudo: SudoConfig { key: Some(root_key) },
 		council: Default::default(),
 		treasury: Default::default(),
-		parachain_info: hashed_parachain_runtime::ParachainInfoConfig { parachain_id: id },
+		parachain_info: hashed_parachain_runtime::ParachainInfoConfig {
+			parachain_id: id,
+			..Default::default()
+		},
 		collator_selection: hashed_parachain_runtime::CollatorSelectionConfig {
 			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
 			candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
@@ -112,6 +116,7 @@ fn md5_genesis(
 		parachain_system: Default::default(),
 		polkadot_xcm: hashed_parachain_runtime::PolkadotXcmConfig {
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
+			..Default::default()
 		},
 	}
 }

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -13,7 +13,7 @@ pub mod md5;
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec =
-	sc_service::GenericChainSpec<hashed_parachain_runtime::GenesisConfig, Extensions>;
+	sc_service::GenericChainSpec<hashed_parachain_runtime::RuntimeGenesisConfig, Extensions>;
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
@@ -199,12 +199,13 @@ fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root_key: AccountId,
 	id: ParaId,
-) -> hashed_parachain_runtime::GenesisConfig {
-	hashed_parachain_runtime::GenesisConfig {
+) -> hashed_parachain_runtime::RuntimeGenesisConfig {
+	hashed_parachain_runtime::RuntimeGenesisConfig {
 		system: hashed_parachain_runtime::SystemConfig {
 			code: hashed_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
+				..Default::default()
 		},
 		balances: hashed_parachain_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
@@ -213,7 +214,10 @@ fn testnet_genesis(
 		sudo: SudoConfig { key: Some(root_key) },
 		council: Default::default(),
 		treasury: Default::default(),
-		parachain_info: hashed_parachain_runtime::ParachainInfoConfig { parachain_id: id },
+		parachain_info: hashed_parachain_runtime::ParachainInfoConfig {
+			parachain_id: id,
+			..Default::default()
+		},
 		collator_selection: hashed_parachain_runtime::CollatorSelectionConfig {
 			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
 			candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
@@ -238,6 +242,7 @@ fn testnet_genesis(
 		parachain_system: Default::default(),
 		polkadot_xcm: hashed_parachain_runtime::PolkadotXcmConfig {
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
+			..Default::default()
 		},
 	}
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -44,12 +44,25 @@ pub enum Subcommand {
 	TryRuntime,
 }
 
+const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(
+	r#"<bold><underline>Examples:</></>
+   <bold>hashed-parachain build-spec --disable-default-bootnode > plain-parachain-chainspec.json</>
+           Export a chainspec for a local testnet in json format.
+   <bold>hashed-parachain --chain plain-parachain-chainspec.json --tmp -- --chain rococo-local</>
+           Launch a full node with chain specification loaded from plain-parachain-chainspec.json.
+   <bold>hashed-parachain</>
+           Launch a full node with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+   <bold>hashed-parachain --collator</>
+           Launch a collator with default parachain <italic>local-testnet</> and relay chain <italic>rococo-local</>.
+ "#
+);
 #[derive(Debug, clap::Parser)]
 #[command(
 	propagate_version = true,
 	args_conflicts_with_subcommands = true,
 	subcommand_negates_reqs = true
 )]
+#[clap(after_help = AFTER_HELP_EXAMPLE)]
 pub struct Cli {
 	#[command(subcommand)]
 	pub subcommand: Option<Subcommand>,
@@ -92,7 +105,11 @@ impl RelayChainCli {
 	) -> Self {
 		let extension = crate::chain_spec::Extensions::try_get(&*para_config.chain_spec);
 		let chain_id = extension.map(|e| e.relay_chain.clone());
-		let base_path = para_config.base_path.as_ref().map(|x| x.path().join("polkadot"));
-		Self { base_path, chain_id, base: clap::Parser::parse_from(relay_chain_args) }
+		let base_path = para_config.base_path.path().join("polkadot");
+		Self {
+			base_path: Some(base_path),
+			chain_id,
+			base: clap::Parser::parse_from(relay_chain_args),
+		}
 	}
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,23 +1,21 @@
 use std::net::SocketAddr;
 
-use codec::Encode;
-use cumulus_client_cli::generate_genesis_block;
+
 use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use hashed_parachain_runtime::Block;
 use log::{info, warn};
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
-	NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,
+	NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
-use sp_core::hexdisplay::HexDisplay;
-use sp_runtime::traits::{AccountIdConversion, Block as BlockT};
+use sp_runtime::traits::{AccountIdConversion};
 
 use crate::{
 	chain_spec,
 	cli::{Cli, RelayChainCli, Subcommand},
-	service::{new_partial, ParachainNativeExecutor},
+	service::new_partial,
 };
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
@@ -66,9 +64,6 @@ impl SubstrateCli for Cli {
 		load_spec(id)
 	}
 
-	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		&hashed_parachain_runtime::VERSION
-	}
 }
 
 impl SubstrateCli for RelayChainCli {
@@ -104,10 +99,6 @@ impl SubstrateCli for RelayChainCli {
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
-	}
-
-	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		polkadot_cli::Cli::native_runtime_version(chain_spec)
 	}
 }
 
@@ -177,10 +168,10 @@ pub fn run() -> Result<()> {
 		},
 		Some(Subcommand::ExportGenesisState(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|_config| {
-				let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
-				let state_version = Cli::native_runtime_version(&spec).state_version();
-				cmd.run::<Block>(&*spec, state_version)
+			runner.sync_run(|config| {
+				let partials = new_partial(&config)?;
+
+				cmd.run(&*config.chain_spec, &*partials.client)
 			})
 		},
 		Some(Subcommand::ExportGenesisWasm(cmd)) => {
@@ -194,28 +185,26 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			// Switch on the concrete benchmark sub-command-
 			match cmd {
-				BenchmarkCmd::Pallet(cmd) => {
+				BenchmarkCmd::Pallet(cmd) =>
 					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<Block, ParachainNativeExecutor>(config))
+						runner.sync_run(|config| cmd.run::<Block, ()>(config))
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."
 							.into())
-					}
-				},
+					},
 				BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
 					let partials = new_partial(&config)?;
 					cmd.run(partials.client)
 				}),
 				#[cfg(not(feature = "runtime-benchmarks"))]
-				BenchmarkCmd::Storage(_) => {
+				BenchmarkCmd::Storage(_) =>
 					return Err(sc_cli::Error::Input(
 						"Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
 							.into(),
 					)
-					.into())
-				},
+					.into()),
 				#[cfg(feature = "runtime-benchmarks")]
 				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
 					let partials = new_partial(&config)?;
@@ -223,9 +212,8 @@ pub fn run() -> Result<()> {
 					let storage = partials.backend.expose_storage();
 					cmd.run(config, partials.client.clone(), db, storage)
 				}),
-				BenchmarkCmd::Machine(cmd) => {
-					runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()))
-				},
+				BenchmarkCmd::Machine(cmd) =>
+					runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())),
 				// NOTE: this allows the Client to leniently implement
 				// new benchmark commands without requiring a companion MR.
 				#[allow(unreachable_patterns)]
@@ -235,15 +223,12 @@ pub fn run() -> Result<()> {
 		#[cfg(feature = "try-runtime")]
 		Some(Subcommand::TryRuntime(cmd)) => {
 			use parachain_template_runtime::MILLISECS_PER_BLOCK;
-			use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
 			use try_runtime_cli::block_building_info::timestamp_with_aura_info;
 
 			let runner = cli.create_runner(cmd)?;
 
-			type HostFunctionsOf<E> = ExtendedHostFunctions<
-				sp_io::SubstrateHostFunctions,
-				<E as NativeExecutionDispatch>::ExtendHostFunctions,
-			>;
+			type HostFunctions =
+				(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
 
 			// grab the task manager.
 			let registry = &runner.config().prometheus_config.as_ref().map(|cfg| &cfg.registry);
@@ -254,12 +239,7 @@ pub fn run() -> Result<()> {
 			let info_provider = timestamp_with_aura_info(MILLISECS_PER_BLOCK);
 
 			runner.async_run(|_| {
-				Ok((
-					cmd.run::<Block, HostFunctionsOf<ParachainNativeExecutor>, _>(Some(
-						info_provider,
-					)),
-					task_manager,
-				))
+				Ok((cmd.run::<Block, HostFunctions, _>(Some(info_provider)), task_manager))
 			})
 		},
 		#[cfg(not(feature = "try-runtime"))]
@@ -271,15 +251,16 @@ pub fn run() -> Result<()> {
 			let collator_options = cli.run.collator_options();
 
 			runner.run_node_until_exit(|config| async move {
-				let hwbench = (!cli.no_hardware_benchmarks).then_some(
-					config.database.path().map(|database_path| {
-						let _ = std::fs::create_dir_all(&database_path);
+				let hwbench = (!cli.no_hardware_benchmarks)
+					.then_some(config.database.path().map(|database_path| {
+						let _ = std::fs::create_dir_all(database_path);
 						sc_sysinfo::gather_hwbench(Some(database_path))
-					})).flatten();
+					}))
+					.flatten();
 
 				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
 					.map(|e| e.para_id)
-					.ok_or_else(|| "Could not find parachain ID in chain-spec.")?;
+					.ok_or("Could not find parachain ID in chain-spec.")?;
 
 				let polkadot_cli = RelayChainCli::new(
 					&config,
@@ -289,25 +270,26 @@ pub fn run() -> Result<()> {
 				let id = ParaId::from(para_id);
 
 				let parachain_account =
-					AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(&id);
-
-				let state_version = Cli::native_runtime_version(&config.chain_spec).state_version();
-				let block: Block = generate_genesis_block(&*config.chain_spec, state_version)
-					.map_err(|e| format!("{:?}", e))?;
-				let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
+					AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(
+						&id,
+					);
 
 				let tokio_handle = config.tokio_handle.clone();
 				let polkadot_config =
 					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
 						.map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				info!("Parachain id: {:?}", id);
-				info!("Parachain Account: {}", parachain_account);
-				info!("Parachain genesis state: {}", genesis_state);
+				info!("Parachain Account: {parachain_account}");
 				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
 
-				if !collator_options.relay_chain_rpc_urls.is_empty() && cli.relay_chain_args.len() > 0 {
-					warn!("Detected relay chain node arguments together with --relay-chain-rpc-url. This command starts a minimal Polkadot node that only uses a network-related subset of all relay chain CLI options.");
+				if !collator_options.relay_chain_rpc_urls.is_empty() &&
+					!cli.relay_chain_args.is_empty()
+				{
+					warn!(
+						"Detected relay chain node arguments together with --relay-chain-rpc-url. \
+							This command starts a minimal Polkadot node that only uses a \
+							network-related subset of all relay chain CLI options."
+					);
 				}
 
 				crate::service::start_parachain_node(
@@ -330,12 +312,8 @@ impl DefaultConfigurationValues for RelayChainCli {
 		30334
 	}
 
-	fn rpc_ws_listen_port() -> u16 {
+	fn rpc_listen_port() -> u16 {
 		9945
-	}
-
-	fn rpc_http_listen_port() -> u16 {
-		9934
 	}
 
 	fn prometheus_listen_port() -> u16 {
@@ -367,16 +345,8 @@ impl CliConfiguration<Self> for RelayChainCli {
 			.or_else(|| self.base_path.clone().map(Into::into)))
 	}
 
-	fn rpc_http(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
-		self.base.base.rpc_http(default_listen_port)
-	}
-
-	fn rpc_ipc(&self) -> Result<Option<String>> {
-		self.base.base.rpc_ipc()
-	}
-
-	fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
-		self.base.base.rpc_ws(default_listen_port)
+	fn rpc_addr(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+		self.base.base.rpc_addr(default_listen_port)
 	}
 
 	fn prometheus_config(
@@ -422,8 +392,8 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.rpc_methods()
 	}
 
-	fn rpc_ws_max_connections(&self) -> Result<Option<usize>> {
-		self.base.base.rpc_ws_max_connections()
+	fn rpc_max_connections(&self) -> Result<u32> {
+		self.base.base.rpc_max_connections()
 	}
 
 	fn rpc_cors(&self, is_dev: bool) -> Result<Option<Vec<String>>> {

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use hashed_parachain_runtime::{opaque::Block, AccountId, Balance, Index as Nonce};
+use hashed_parachain_runtime::{opaque::Block, AccountId, Balance, Nonce};
 
 use sc_client_api::AuxStore;
 pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -21,13 +21,17 @@ use cumulus_relay_chain_interface::RelayChainInterface;
 
 // Substrate Imports
 use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
+use sc_client_api::Backend;
 use sc_consensus::ImportQueue;
-use sc_executor::NativeElseWasmExecutor;
+use sc_executor::{
+	HeapAllocStrategy, NativeElseWasmExecutor, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY,
+};
 use sc_network::NetworkBlock;
 use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
-use sp_keystore::SyncCryptoStorePtr;
+use sc_transaction_pool_api::OffchainTransactionPoolFactory;
+use sp_keystore::KeystorePtr;
 use substrate_prometheus_endpoint::Registry;
 
 /// Native executor type.
@@ -81,12 +85,19 @@ pub fn new_partial(
 		})
 		.transpose()?;
 
-	let executor = ParachainExecutor::new(
-		config.wasm_method,
-		config.default_heap_pages,
-		config.max_runtime_instances,
-		config.runtime_cache_size,
-	);
+	let heap_pages = config
+		.default_heap_pages
+		.map_or(DEFAULT_HEAP_ALLOC_STRATEGY, |h| HeapAllocStrategy::Static { extra_pages: h as _ });
+
+	let wasm = WasmExecutor::builder()
+		.with_execution_method(config.wasm_method)
+		.with_onchain_heap_alloc_strategy(heap_pages)
+		.with_offchain_heap_alloc_strategy(heap_pages)
+		.with_max_runtime_instances(config.max_runtime_instances)
+		.with_runtime_cache_size(config.runtime_cache_size)
+		.build();
+
+	let executor = ParachainExecutor::new_with_wasm_executor(wasm);
 
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
@@ -148,6 +159,7 @@ async fn start_node_impl(
 
 	let params = new_partial(&parachain_config)?;
 	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
+	let net_config = sc_network::config::FullNetworkConfiguration::new(&parachain_config.network);
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -173,6 +185,7 @@ async fn start_node_impl(
 	let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
 		build_network(BuildNetworkParams {
 			parachain_config: &parachain_config,
+			net_config,
 			client: client.clone(),
 			transaction_pool: transaction_pool.clone(),
 			para_id,
@@ -183,11 +196,25 @@ async fn start_node_impl(
 		.await?;
 
 	if parachain_config.offchain_worker.enabled {
-		sc_service::build_offchain_workers(
-			&parachain_config,
-			task_manager.spawn_handle(),
-			client.clone(),
-			network.clone(),
+		use futures::FutureExt;
+
+		task_manager.spawn_handle().spawn(
+			"offchain-workers-runner",
+			"offchain-work",
+			sc_offchain::OffchainWorkers::new(sc_offchain::OffchainWorkerOptions {
+				runtime_api_provider: client.clone(),
+				keystore: Some(params.keystore_container.keystore()),
+				offchain_db: backend.offchain_storage(),
+				transaction_pool: Some(OffchainTransactionPoolFactory::new(
+					transaction_pool.clone(),
+				)),
+				network_provider: network.clone(),
+				is_validator: parachain_config.role.is_authority(),
+				enable_http_requests: false,
+				custom_extensions: move |_| vec![],
+			})
+			.run(client.clone(), task_manager.spawn_handle())
+			.boxed(),
 		);
 	}
 
@@ -212,7 +239,7 @@ async fn start_node_impl(
 		transaction_pool: transaction_pool.clone(),
 		task_manager: &mut task_manager,
 		config: parachain_config,
-		keystore: params.keystore_container.sync_keystore(),
+		keystore: params.keystore_container.keystore(),
 		backend,
 		network: network.clone(),
 		sync_service: sync_service.clone(),
@@ -262,8 +289,8 @@ async fn start_node_impl(
 			&task_manager,
 			relay_chain_interface.clone(),
 			transaction_pool,
-			sync_service,
-			params.keystore_container.sync_keystore(),
+			sync_service.clone(),
+			params.keystore_container.keystore(),
 			force_authoring,
 			para_id,
 		)?;
@@ -282,6 +309,7 @@ async fn start_node_impl(
 			collator_key: collator_key.expect("Command line arguments do not allow this. qed"),
 			relay_chain_slot_duration,
 			recovery_handle: Box::new(overseer_handle),
+			sync_service,
 		};
 
 		start_collator(params).await?;
@@ -295,6 +323,7 @@ async fn start_node_impl(
 			relay_chain_slot_duration,
 			import_queue: import_queue_service,
 			recovery_handle: Box::new(overseer_handle),
+			sync_service,
 		};
 
 		start_full_node(params)?;
@@ -352,7 +381,7 @@ fn build_consensus(
 	relay_chain_interface: Arc<dyn RelayChainInterface>,
 	transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
 	sync_oracle: Arc<SyncingService<Block>>,
-	keystore: SyncCryptoStorePtr,
+	keystore: KeystorePtr,
 	force_authoring: bool,
 	para_id: ParaId,
 ) -> Result<Box<dyn ParachainConsensus<Block>>, sc_service::Error> {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,7 +25,7 @@ smallvec = "1.11.0"
 # Hashed Dependencies
 pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
-# pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
+pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 # pallet-bitcoin-vaults = { path = "../../hashed-pallets/pallets/bitcoin-vaults", default-features = false }
 pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
@@ -137,7 +137,7 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	# Local Pallets
-	# "pallet-bitcoin-vaults/std",
+	"pallet-bitcoin-vaults/std",
 	"pallet-gated-marketplace/std",
 	"pallet-rbac/std",
 	"pallet-confidential-docs/std",
@@ -246,7 +246,7 @@ try-runtime = [
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
 	# Hashed pallets
-	# "pallet-bitcoin-vaults/try-runtime",
+	"pallet-bitcoin-vaults/try-runtime",
 	"pallet-confidential-docs/try-runtime",
 	"pallet-fruniques/try-runtime",
 	"pallet-fund-admin-records/try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,7 +25,8 @@ smallvec = "1.11.0"
 # Hashed Dependencies
 pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
-pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
+# pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
+# pallet-bitcoin-vaults = { path = "../../hashed-pallets/pallets/bitcoin-vaults", default-features = false }
 pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
 pallet-confidential-docs = { git = "https://github.com/hashed-io/hashed-pallets", branch = "fix-dependencies-polkadotv1", default-features = false }
@@ -136,7 +137,7 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	# Local Pallets
-	"pallet-bitcoin-vaults/std",
+	# "pallet-bitcoin-vaults/std",
 	"pallet-gated-marketplace/std",
 	"pallet-rbac/std",
 	"pallet-confidential-docs/std",
@@ -245,7 +246,7 @@ try-runtime = [
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
 	# Hashed pallets
-	"pallet-bitcoin-vaults/try-runtime",
+	# "pallet-bitcoin-vaults/try-runtime",
 	"pallet-confidential-docs/try-runtime",
 	"pallet-fruniques/try-runtime",
 	"pallet-fund-admin-records/try-runtime",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -778,6 +778,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::Balances(..)
 					| RuntimeCall::Assets(..)
 					| RuntimeCall::Uniques(..)
+					| RuntimeCall::Fruniques(..)
 					| RuntimeCall::Vesting(pallet_vesting::Call::vested_transfer { .. })
 					| RuntimeCall::Indices(pallet_indices::Call::transfer { .. })
 			),
@@ -944,18 +945,18 @@ parameter_types! {
 	pub const MaxProposalsPerVault: u32 = 100;
 }
 
-// impl pallet_bitcoin_vaults::Config for Runtime {
-// 	type AuthorityId = pallet_bitcoin_vaults::types::crypto::TestAuthId;
-// 	type RuntimeEvent = RuntimeEvent;
-// 	type ChangeBDKOrigin = RootOrThreeFifthsOfCouncil;
-// 	type XPubLen = XPubLen;
-// 	type PSBTMaxLen = PSBTMaxLen;
-// 	type MaxVaultsPerUser = MaxVaultsPerUser;
-// 	type MaxCosignersPerVault = MaxCosignersPerVault;
-// 	type VaultDescriptionMaxLen = VaultDescriptionMaxLen;
-// 	type OutputDescriptorMaxLen = OutputDescriptorMaxLen;
-// 	type MaxProposalsPerVault = MaxProposalsPerVault;
-// }
+impl pallet_bitcoin_vaults::Config for Runtime {
+	type AuthorityId = pallet_bitcoin_vaults::types::crypto::TestAuthId;
+	type RuntimeEvent = RuntimeEvent;
+	type ChangeBDKOrigin = RootOrThreeFifthsOfCouncil;
+	type XPubLen = XPubLen;
+	type PSBTMaxLen = PSBTMaxLen;
+	type MaxVaultsPerUser = MaxVaultsPerUser;
+	type MaxCosignersPerVault = MaxCosignersPerVault;
+	type VaultDescriptionMaxLen = VaultDescriptionMaxLen;
+	type OutputDescriptorMaxLen = OutputDescriptorMaxLen;
+	type MaxProposalsPerVault = MaxProposalsPerVault;
+}
 
 parameter_types! {
 	pub const MaxOwnedDocs: u32 = 100;
@@ -1145,6 +1146,7 @@ construct_runtime!(
 		Treasury: pallet_treasury::{Pallet, Call, Storage, Config<T>, Event<T>} = 62,
 		ChildBounties: pallet_child_bounties::{Pallet, Call, Storage, Event<T>} = 63,
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 64,
+		Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>}  = 65,
 		// AssetTxPayment: pallet_asset_tx_payment::{Pallet, Call, Storage, Event<T>} = 16,
 
 		// Governance Related
@@ -1166,7 +1168,7 @@ construct_runtime!(
 		// Custom Pallets
 		Fruniques: pallet_fruniques::{Pallet, Call, Storage, Event<T>}  = 151,
 		GatedMarketplace: pallet_gated_marketplace::{Pallet, Call, Storage, Event<T>}  = 152,
-		// BitcoinVaults: pallet_bitcoin_vaults::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 154,
+		BitcoinVaults: pallet_bitcoin_vaults::{Pallet, Call, Storage, Event<T>}  = 154,
 		RBAC: pallet_rbac::{Pallet, Call, Storage, Event<T>}  = 155,
 		ConfidentialDocs: pallet_confidential_docs::{Pallet, Call, Storage, Event<T>}  = 156,
 		FundAdminRecords: pallet_fund_admin_records::{Pallet, Call, Storage, Event<T>}  = 157,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,7 +31,7 @@ use frame_support::{
 	construct_runtime,
 	dispatch::DispatchClass,
 	parameter_types,
-	traits::{ AsEnsureOriginWithArg, ConstU32, ConstU64, ConstU128, ConstU8, EitherOfDiverse, Everything, InstanceFilter, WithdrawReasons,},
+	traits::{ AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, ConstU128, ConstU8, EitherOfDiverse, Everything, InstanceFilter, WithdrawReasons,},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
@@ -68,6 +68,9 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 
 /// Balance of an account.
 pub type Balance = u128;
+
+/// Index of a transaction in the chain.
+pub type Nonce = u32;
 
 pub type AccountIndex = u32;
 
@@ -275,15 +278,13 @@ impl frame_system::Config for Runtime {
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
 	type Lookup = AccountIdLookup<AccountId, ()>;
 	/// The index type for storing how many extrinsics an account has signed.
-	type Index = Index;
-	/// The index type for blocks.
-	type BlockNumber = BlockNumber;
+	type Nonce = Nonce;
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
 	type Hashing = BlakeTwo256;
-	/// The header type.
-	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	/// The block type.
+	type Block = Block;
 	/// The ubiquitous event type.
 	type RuntimeEvent = RuntimeEvent;
 	/// The ubiquitous origin type.
@@ -346,6 +347,10 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 	type MaxReserves = ConstU32<50>;
 	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type FreezeIdentifier = ();
+	type MaxHolds = ConstU32<0>;
+	type MaxFreezes = ConstU32<0>;
 }
 
 parameter_types! {
@@ -360,6 +365,12 @@ impl pallet_transaction_payment::Config for Runtime {
 	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 	type OperationalFeeMultiplier = ConstU8<5>;
+}
+
+impl pallet_sudo::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -424,12 +435,13 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
+	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 }
 
 parameter_types! {
 	pub const PotId: PalletId = PalletId(*b"PotStake");
 	pub const MaxCandidates: u32 = 1000;
-	pub const MinCandidates: u32 = 5;
+	pub const MinEligibleCollators: u32 = 5;
 	pub const SessionLength: BlockNumber = 6 * HOURS;
 	pub const MaxInvulnerables: u32 = 100;
 	pub const ExecutiveBody: BodyId = BodyId::Executive;
@@ -444,7 +456,7 @@ impl pallet_collator_selection::Config for Runtime {
 	type UpdateOrigin = CollatorSelectionUpdateOrigin;
 	type PotId = PotId;
 	type MaxCandidates = MaxCandidates;
-	type MinCandidates = MinCandidates;
+	type MinEligibleCollators = MinEligibleCollators;
 	type MaxInvulnerables = MaxInvulnerables;
 	// should be a multiple of session or things will get inconsistent
 	type KickThreshold = Period;
@@ -545,6 +557,7 @@ impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = u128;
 	type AssetId = u32;
+	type AssetIdParameter = u32;
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type ForceOrigin = EnsureRoot<AccountId>;
@@ -558,7 +571,6 @@ impl pallet_assets::Config for Runtime {
 	type Extra = ();
 	type WeightInfo = ();
 	type RemoveItemsLimit = RemoveItemsLimit;
-	type AssetIdParameter = u32;
 	type CallbackHandle = ();
 }
 
@@ -567,6 +579,7 @@ parameter_types! {
 	pub CouncilMotionDuration: BlockNumber = 3 * DAYS;
 	pub const CouncilMaxProposals: u32 = 100;
 	pub const CouncilMaxMembers: u32 = 100;
+	// pub MaxCollectivesProposalWeight: Weight = Perbill::from_percent(50) * BlockWeights::get().max_block;
 }
 
 type CouncilCollective = pallet_collective::Instance1;
@@ -580,38 +593,37 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type DefaultVote = pallet_collective::PrimeDefaultVote;
 	type WeightInfo = ();
 	type SetMembersOrigin = EnsureRoot<AccountId>;
+	type MaxProposalWeight = ();
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
 
 parameter_types! {
-	pub const CandidateDeposit: Balance = 1000 * CENTS;
-	pub const WrongSideDeduction: Balance = 200 * CENTS;
-	pub const MaxStrikes: u32 = 10;
-	pub const RotationPeriod: BlockNumber = 7 * DAYS;
+	pub const GraceStrikes: u32 = 10;
 	pub const PeriodSpend: Balance = 50000 * CENTS;
 	pub const MaxLockDuration: BlockNumber = 36 * 30 * DAYS;
+	pub const VotingPeriod: BlockNumber = 7 * DAYS;
+	pub const ClaimPeriod: BlockNumber = 7 * DAYS;
 	pub const ChallengePeriod: BlockNumber = 7 * DAYS;
-	pub const MaxCandidateIntake: u32 = 1;
 	pub const SocietyPalletId: PalletId = PalletId(*b"py/socie");
 }
 
 impl pallet_society::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type PalletId = SocietyPalletId;
 	type Currency = Balances;
 	type Randomness = RandomnessCollectiveFlip;
-	type CandidateDeposit = CandidateDeposit;
-	type WrongSideDeduction = WrongSideDeduction;
-	type MaxStrikes = MaxStrikes;
+	type GraceStrikes = GraceStrikes;
 	type PeriodSpend = PeriodSpend;
-	type MembershipChanged = ();
-	type RotationPeriod = RotationPeriod;
+	type VotingPeriod = VotingPeriod;
+	type ClaimPeriod = ClaimPeriod;
 	type MaxLockDuration = MaxLockDuration;
 	type FounderSetOrigin = EnsureRoot<AccountId>;
-	type SuspensionJudgementOrigin = pallet_society::EnsureFounder<Runtime>;
 	type ChallengePeriod = ChallengePeriod;
-	type MaxCandidateIntake = MaxCandidateIntake;
-	type PalletId = SocietyPalletId;
+	type MaxPayouts = ConstU32<5>;
+	type MaxBids = ConstU32<3>;
+	type WeightInfo = ();
+
 }
 
 parameter_types! {
@@ -719,11 +731,6 @@ impl pallet_vesting::Config for Runtime {
 	// `VestingInfo` encode length is 36bytes. 28 schedules gets encoded as 1009 bytes, which is the
 	// highest number of schedules that encodes less than 2^10.
 	const MAX_VESTING_SCHEDULES: u32 = 28;
-}
-
-impl pallet_sudo::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
 }
 
 parameter_types! {
@@ -917,10 +924,7 @@ parameter_types! {
 
 impl pallet_rbac::Config for Runtime {
   type RuntimeEvent = RuntimeEvent;
-  type RemoveOrigin = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 5>,
-  >;
+  type RemoveOrigin = RootOrThreeFifthsOfCouncil;
   type MaxScopesPerPallet = MaxScopesPerPallet;
   type MaxRolesPerPallet = MaxRolesPerPallet;
   type RoleMaxLen = RoleMaxLen;
@@ -940,18 +944,18 @@ parameter_types! {
 	pub const MaxProposalsPerVault: u32 = 100;
 }
 
-impl pallet_bitcoin_vaults::Config for Runtime {
-	type AuthorityId = pallet_bitcoin_vaults::types::crypto::TestAuthId;
-	type RuntimeEvent = RuntimeEvent;
-	type ChangeBDKOrigin = RootOrThreeFifthsOfCouncil;
-	type XPubLen = XPubLen;
-	type PSBTMaxLen = PSBTMaxLen;
-	type MaxVaultsPerUser = MaxVaultsPerUser;
-	type MaxCosignersPerVault = MaxCosignersPerVault;
-	type VaultDescriptionMaxLen = VaultDescriptionMaxLen;
-	type OutputDescriptorMaxLen = OutputDescriptorMaxLen;
-	type MaxProposalsPerVault = MaxProposalsPerVault;
-}
+// impl pallet_bitcoin_vaults::Config for Runtime {
+// 	type AuthorityId = pallet_bitcoin_vaults::types::crypto::TestAuthId;
+// 	type RuntimeEvent = RuntimeEvent;
+// 	type ChangeBDKOrigin = RootOrThreeFifthsOfCouncil;
+// 	type XPubLen = XPubLen;
+// 	type PSBTMaxLen = PSBTMaxLen;
+// 	type MaxVaultsPerUser = MaxVaultsPerUser;
+// 	type MaxCosignersPerVault = MaxCosignersPerVault;
+// 	type VaultDescriptionMaxLen = VaultDescriptionMaxLen;
+// 	type OutputDescriptorMaxLen = OutputDescriptorMaxLen;
+// 	type MaxProposalsPerVault = MaxProposalsPerVault;
+// }
 
 parameter_types! {
 	pub const MaxOwnedDocs: u32 = 100;
@@ -968,10 +972,7 @@ parameter_types! {
 
 impl pallet_confidential_docs::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RemoveOrigin = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 5>,
-	>;
+	type RemoveOrigin = RootOrThreeFifthsOfCouncil;
 	type MaxOwnedDocs = MaxOwnedDocs;
 	type MaxSharedFromDocs = MaxSharedFromDocs;
 	type MaxSharedToDocs = MaxSharedToDocs;
@@ -992,6 +993,7 @@ impl pallet_mapped_assets::Config for Runtime {
   type RuntimeEvent = RuntimeEvent;
   type Balance = u128;
   type AssetId = u32;
+  type AssetIdParameter = u32;
   type Currency = Balances;
   type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
   type ForceOrigin = EnsureRoot<AccountId>;
@@ -1004,20 +1006,14 @@ impl pallet_mapped_assets::Config for Runtime {
   type Freezer = ();
   type Extra = ();
   type WeightInfo = ();
-  type MaxReserves = MaxReserves;
-  type ReserveIdentifier = u32;
   type RemoveItemsLimit = RemoveItemsLimit;
-  type AssetIdParameter = u32;
-  type CallbackHandle = DefaultCallback;
+  type CallbackHandle = ();
   type Rbac = RBAC;
 }
 
 impl pallet_fruniques::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type RemoveOrigin = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 5>,
-	>;
+	type RemoveOrigin = RootOrThreeFifthsOfCouncil;
 	type Rbac = RBAC;
 	type ChildMaxLen = ChildMaxLen;
 	type MaxParentsInCollection = MaxParentsInCollection;
@@ -1073,10 +1069,7 @@ parameter_types! {
 
 impl pallet_fund_admin_records::Config for Runtime {
   type RuntimeEvent = RuntimeEvent;
-  type RemoveOrigin = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 5>,
-  >;
+  type RemoveOrigin = RootOrThreeFifthsOfCouncil;
   type Timestamp = Timestamp;
   type Moment = u64;
   type MaxRecordsAtTime = MaxRecordsAtTime;
@@ -1118,103 +1111,11 @@ impl pallet_uniques::Config for Runtime {
 	type Locker = ();
 }
 
-impl pallet_fruniques::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RemoveOrigin = RootOrThreeFifthsOfCouncil;
-	type ChildMaxLen = ChildMaxLen;
-	type MaxParentsInCollection = MaxParentsInCollection;
-	type Rbac = RBAC;
-}
 
-parameter_types! {
-	pub const LabelMaxLen:u32 = 32;
-	pub const MaxAuthsPerMarket:u32 = 3; // 1 of each role (1 owner, 1 admin, etc.)
-	pub const MaxRolesPerAuth: u32 = 2;
-	pub const MaxApplicants: u32 = 10;
-	pub const MaxBlockedUsersPerMarket: u32 = 100;
-	pub const NotesMaxLen: u32 = 256;
-	pub const MaxFeedbackLen: u32 = 256;
-	pub const NameMaxLen: u32 = 100;
-	pub const MaxFiles: u32 = 10;
-	pub const MaxApplicationsPerCustodian: u32 = 10;
-	pub const MaxMarketsPerItem: u32 = 10;
-	pub const MaxOffersPerMarket: u32 = 100;
-}
-
-impl pallet_gated_marketplace::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type MaxAuthsPerMarket = MaxAuthsPerMarket;
-	type MaxRolesPerAuth = MaxRolesPerAuth;
-	type MaxApplicants = MaxApplicants;
-	type MaxBlockedUsersPerMarket = MaxBlockedUsersPerMarket;
-	type LabelMaxLen = LabelMaxLen;
-	type NotesMaxLen = NotesMaxLen;
-	type MaxFeedbackLen = MaxFeedbackLen;
-	type NameMaxLen = NameMaxLen;
-	type MaxFiles = MaxFiles;
-	type MaxApplicationsPerCustodian = MaxApplicationsPerCustodian;
-	type MaxMarketsPerItem = MaxMarketsPerItem;
-	type MaxOffersPerMarket = MaxOffersPerMarket;
-	type Timestamp = Timestamp;
-	type Moment = Moment;
-	type Rbac = RBAC;
-}
-
-parameter_types! {
-	pub const MaxScopesPerPallet: u32 = 1000;
-	pub const MaxRolesPerPallet: u32 = 20;
-	pub const RoleMaxLen: u32 = 30;
-	pub const PermissionMaxLen: u32 = 30;
-	pub const MaxPermissionsPerRole: u32 = 12;
-	pub const MaxRolesPerUser: u32 = 10;
-	pub const MaxUsersPerRole: u32 = 10;
-}
-
-impl pallet_rbac::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type MaxScopesPerPallet = MaxScopesPerPallet;
-	type MaxRolesPerPallet = MaxRolesPerPallet;
-	type RoleMaxLen = RoleMaxLen;
-	type PermissionMaxLen = PermissionMaxLen;
-	type MaxPermissionsPerRole = MaxPermissionsPerRole;
-	type MaxRolesPerUser = MaxRolesPerUser;
-	type MaxUsersPerRole = MaxUsersPerRole;
-}
-
-parameter_types! {
-	pub const MaxOwnedDocs: u32 = 100;
-	pub const MaxSharedFromDocs: u32 = 100;
-	pub const MaxSharedToDocs: u32 = 100;
-	pub const DocNameMinLen: u32 = 3;
-	pub const DocNameMaxLen: u32 = 50;
-	pub const DocDescMinLen: u32 = 5;
-	pub const DocDescMaxLen: u32 = 100;
-	pub const GroupNameMinLen: u32 = 3;
-	pub const GroupNameMaxLen: u32 = 50;
-	pub const MaxMemberGroups: u32 = 100;
-}
-
-impl pallet_confidential_docs::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RemoveOrigin = RootOrThreeFifthsOfCouncil;
-	type MaxOwnedDocs = MaxOwnedDocs;
-	type MaxSharedFromDocs = MaxSharedFromDocs;
-	type MaxSharedToDocs = MaxSharedToDocs;
-	type DocNameMinLen = DocNameMinLen;
-	type DocNameMaxLen = DocNameMaxLen;
-	type DocDescMinLen = DocDescMinLen;
-	type DocDescMaxLen = DocDescMaxLen;
-	type GroupNameMinLen = GroupNameMinLen;
-	type GroupNameMaxLen = GroupNameMaxLen;
-	type MaxMemberGroups = MaxMemberGroups;
-}
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
-	pub enum Runtime where
-		Block = Block,
-		NodeBlock = opaque::Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+	pub enum Runtime
 	{
 		// System support stuff.
 		System: frame_system = 0,
@@ -1241,7 +1142,7 @@ construct_runtime!(
 
 		// Additional pallets
 		Bounties: pallet_bounties::{Pallet, Call, Storage, Event<T>} = 61,
-		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 62,
+		Treasury: pallet_treasury::{Pallet, Call, Storage, Config<T>, Event<T>} = 62,
 		ChildBounties: pallet_child_bounties::{Pallet, Call, Storage, Event<T>} = 63,
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 64,
 		// AssetTxPayment: pallet_asset_tx_payment::{Pallet, Call, Storage, Event<T>} = 16,
@@ -1263,15 +1164,14 @@ construct_runtime!(
 		Whitelist: pallet_whitelist::{Pallet, Call, Storage, Event<T>}  = 101,
 
 		// Custom Pallets
-		Fruniques: pallet_fruniques::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 151,
-		GatedMarketplace: pallet_gated_marketplace::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 152,
-		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 153,
-		BitcoinVaults: pallet_bitcoin_vaults::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 154,
-		RBAC: pallet_rbac::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 155,
-		ConfidentialDocs: pallet_confidential_docs::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 156,
-		FundAdminRecords: pallet_fund_admin_records::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 157,
-		Afloat: pallet_afloat::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 158,
-		MappedAssets: pallet_mapped_assets::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 159,
+		Fruniques: pallet_fruniques::{Pallet, Call, Storage, Event<T>}  = 151,
+		GatedMarketplace: pallet_gated_marketplace::{Pallet, Call, Storage, Event<T>}  = 152,
+		// BitcoinVaults: pallet_bitcoin_vaults::{Pallet, Call, Storage, Event<T>, ValidateUnsigned}  = 154,
+		RBAC: pallet_rbac::{Pallet, Call, Storage, Event<T>}  = 155,
+		ConfidentialDocs: pallet_confidential_docs::{Pallet, Call, Storage, Event<T>}  = 156,
+		FundAdminRecords: pallet_fund_admin_records::{Pallet, Call, Storage, Event<T>}  = 157,
+		Afloat: pallet_afloat::{Pallet, Call, Storage, Event<T>}  = 158,
+		MappedAssets: pallet_mapped_assets::{Pallet, Call, Storage, Event<T>}  = 159,
 	}
 );
 
@@ -1282,6 +1182,7 @@ mod benches {
 		[pallet_balances, Balances]
 		[pallet_session, SessionBench::<Runtime>]
 		[pallet_timestamp, Timestamp]
+		[pallet_sudo, Sudo]
 		[pallet_collator_selection, CollatorSelection]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 	);
@@ -1315,6 +1216,13 @@ impl_runtime_apis! {
 	impl sp_api::Metadata<Block> for Runtime {
 		fn metadata() -> OpaqueMetadata {
 			OpaqueMetadata::new(Runtime::metadata().into())
+		}
+		fn metadata_at_version(version: u32) -> Option<OpaqueMetadata> {
+			Runtime::metadata_at_version(version)
+		}
+
+		fn metadata_versions() -> sp_std::vec::Vec<u32> {
+			Runtime::metadata_versions()
 		}
 	}
 
@@ -1367,8 +1275,8 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
-		fn account_nonce(account: AccountId) -> Index {
+	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
+		fn account_nonce(account: AccountId) -> Nonce {
 			System::account_nonce(account)
 		}
 	}
@@ -1457,16 +1365,25 @@ impl_runtime_apis! {
 			list_benchmarks!(list, extra);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
-			return (list, storage_info)
+			(list, storage_info)
 		}
 
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-			use frame_benchmarking::{Benchmarking, BenchmarkBatch, TrackedStorageKey};
+			use frame_benchmarking::{BenchmarkError, Benchmarking, BenchmarkBatch};
 
 			use frame_system_benchmarking::Pallet as SystemBench;
-			impl frame_system_benchmarking::Config for Runtime {}
+			impl frame_system_benchmarking::Config for Runtime {
+				fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+					ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
+					Ok(())
+				}
+
+				fn verify_set_code() {
+					System::assert_last_event(cumulus_pallet_parachain_system::Event::<Runtime>::ValidationFunctionStored.into());
+				}
+			}
 
 			use cumulus_pallet_session_benchmarking::Pallet as SessionBench;
 			impl cumulus_pallet_session_benchmarking::Config for Runtime {}

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -2,24 +2,25 @@ use super::{
 	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
 };
-use core::{marker::PhantomData, ops::ControlFlow};
 use frame_support::{
-	log, match_types, parameter_types,
+	match_types, parameter_types,
 	traits::{ConstU32, Everything, Nothing},
 	weights::Weight,
 };
+use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
-use xcm::{latest::prelude::*, CreateMatcher, MatchXcm};
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
-	CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, NativeAsset, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
-	UsingComponents, WithComputedOrigin,
+	CurrencyAdapter, DenyReserveTransferToRelayChain, DenyThenTry, EnsureXcmOrigin,
+	FixedWeightBounds, IsConcrete, NativeAsset, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
+	UsingComponents, WithComputedOrigin, WithUniqueTopic,
 };
-use xcm_executor::{traits::ShouldExecute, XcmExecutor};
+use xcm_executor::XcmExecutor;
 
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
@@ -62,7 +63,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
 	// foreign chains who want to have a local sovereign account on this chain which they control.
 	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
-	// Native converter for Relay-chain (Parent) location; will converts to a `Relay` origin when
+	// Native converter for Relay-chain (Parent) location; will convert to a `Relay` origin when
 	// recognized.
 	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
@@ -89,88 +90,22 @@ match_types! {
 	};
 }
 
-//TODO: move DenyThenTry to polkadot's xcm module.
-/// Deny executing the xcm message if it matches any of the Deny filter regardless of anything else.
-/// If it passes the Deny, and matches one of the Allow cases then it is let through.
-pub struct DenyThenTry<Deny, Allow>(PhantomData<Deny>, PhantomData<Allow>)
-where
-	Deny: ShouldExecute,
-	Allow: ShouldExecute;
-
-impl<Deny, Allow> ShouldExecute for DenyThenTry<Deny, Allow>
-where
-	Deny: ShouldExecute,
-	Allow: ShouldExecute,
-{
-	fn should_execute<RuntimeCall>(
-		origin: &MultiLocation,
-		message: &mut [Instruction<RuntimeCall>],
-		max_weight: Weight,
-		weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		Deny::should_execute(origin, message, max_weight, weight_credit)?;
-		Allow::should_execute(origin, message, max_weight, weight_credit)
-	}
-}
-
-// See issue <https://github.com/paritytech/polkadot/issues/5233>
-pub struct DenyReserveTransferToRelayChain;
-impl ShouldExecute for DenyReserveTransferToRelayChain {
-	fn should_execute<RuntimeCall>(
-		origin: &MultiLocation,
-		message: &mut [Instruction<RuntimeCall>],
-		_max_weight: Weight,
-		_weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		message.matcher().match_next_inst_while(
-			|_| true,
-			|inst| match inst {
-				InitiateReserveWithdraw {
-					reserve: MultiLocation { parents: 1, interior: Here },
-					..
-				} |
-				DepositReserveAsset {
-					dest: MultiLocation { parents: 1, interior: Here }, ..
-				} |
-				TransferReserveAsset {
-					dest: MultiLocation { parents: 1, interior: Here }, ..
-				} => {
-					Err(()) // Deny
-				},
-				// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
-				// `IsReserve` should not allow this, but we just log it here.
-				ReserveAssetDeposited { .. }
-					if matches!(origin, MultiLocation { parents: 1, interior: Here }) =>
-				{
-					log::warn!(
-						target: "xcm::barrier",
-						"Unexpected ReserveAssetDeposited from the Relay Chain",
-					);
-					Ok(ControlFlow::Continue(()))
-				},
-				_ => Ok(ControlFlow::Continue(())),
-			},
-		)?;
-
-		// Permit everything else
-		Ok(())
-	}
-}
-
-pub type Barrier = DenyThenTry<
-	DenyReserveTransferToRelayChain,
-	(
-		TakeWeightCredit,
-		WithComputedOrigin<
-			(
-				AllowTopLevelPaidExecutionFrom<Everything>,
-				AllowExplicitUnpaidExecutionFrom<ParentOrParentsExecutivePlurality>,
-				// ^^^ Parent and its exec plurality get free execution
-			),
-			UniversalLocation,
-			ConstU32<8>,
-		>,
-	),
+pub type Barrier = TrailingSetTopicAsId<
+	DenyThenTry<
+		DenyReserveTransferToRelayChain,
+		(
+			TakeWeightCredit,
+			WithComputedOrigin<
+				(
+					AllowTopLevelPaidExecutionFrom<Everything>,
+					AllowExplicitUnpaidExecutionFrom<ParentOrParentsExecutivePlurality>,
+					// ^^^ Parent and its exec plurality get free execution
+				),
+				UniversalLocation,
+				ConstU32<8>,
+			>,
+		),
+	>,
 >;
 
 pub struct XcmConfig;
@@ -200,6 +135,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalAliases = Nothing;
 	type CallDispatcher = RuntimeCall;
 	type SafeCallFilter = Everything;
+	type Aliasers = Nothing;
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.
@@ -207,12 +143,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
 	// Two routers - use UMP to communicate with the relay chain:
 	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, (), ()>,
 	// ..and XCMP to communicate with the sibling chains.
 	XcmpQueue,
-);
+)>;
 
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {
@@ -246,6 +182,9 @@ impl pallet_xcm::Config for Runtime {
 	type WeightInfo = pallet_xcm::TestWeightInfo;
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
+	type AdminOrigin = EnsureRoot<AccountId>;
+	type MaxRemoteLockConsumers = ConstU32<0>;
+	type RemoteLockConsumerIdentifier = ();
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {


### PR DESCRIPTION
- Updated the frame_system config to account for the type changes in the new version.
- Updated the pallet society config to account for the type changes in the new version.
- Updated all the pallets that have a RemoveOrigin type to use the previously defined RootOrThreeFifthsOfCouncil origin.
- Updated the pallet mapped assets config to account for the type changes in the new version.
- Removed duplicate definition of the pallets fruniques, gated market place and rbac.
- Removed where statement from the Runtime enum.
- Added pallet_sudo to the benchmarking.
- Updated the XcmConfig.
- Added missing methods to the Metadata impl for the runtime.
- Updated the dependencies for the node crate.
- GenesisConfig has been deprecated, so updated chain specs to use RuntimeGenesisConfig.
- SystemConfig genesis config has additional parameters so it was updated to include this additional parameters.
- ParachainInfoConfig genesis config has additional parameters so it was updated to include this additional parameters.
- PolkadotXcmConfig genesis config has additional parameters so it was updated to include this additional parameters.
- Updated the node cli module to account for the latest changes.
- Updated the node command module to account for the latest changes.
- Updated the node rpc module to account for the latest changes.
- Removed ValidateUnsigned object from pallet definitions that dont require it.